### PR TITLE
fix(build): remove sourceMappingURL from svelte build

### DIFF
--- a/scripts/svelte-copy.js
+++ b/scripts/svelte-copy.js
@@ -2,7 +2,7 @@ const fss = require('fs')
 const fsPromises = require('fs').promises
 const path = require('path')
 const svelte = require('svelte/compiler')
-const svelteConfig = require('../svelte.config')
+const autoPreprocess = require('svelte-preprocess')
 
 main()
 
@@ -40,7 +40,13 @@ async function main() {
 
 async function preprocessSvelte(src, dest) {
     const srcCode = await fsPromises.readFile(src, { encoding: 'utf-8' })
-    let { code } = await svelte.preprocess(srcCode, svelteConfig.preprocess, {
+    const preprocess = autoPreprocess({
+        sourceMap: false,
+        typescript: {
+            tsconfigFile: "./tsconfig.lib.json"
+        }
+    })
+    let { code } = await svelte.preprocess(srcCode, preprocess, {
         filename: src
     })
     // oups !


### PR DESCRIPTION
Hi,

This lib is excellent, I use it on a real world project and it helps a lot with query management.

After a couple of month using it, I have few suggestions and feedbacks about the lib.
I will try to help by contributing with some PRs.

Here is the first one.

During the build, this lib preprocess svelte files before packaging but the typescript preprocessor is relying on the `tsconfig.json` base file of the project so it produces sourceMaps files (which are not exported).

This PRs fixes that behavior by passing the typescript preprocessor the good file to use.

Fixes #27 