### PR TITLE
feat(queries): add setEnabled function to queries and infinite queries

### DIFF
--- a/docs/src/pages/guides/infinite-queries.md
+++ b/docs/src/pages/guides/infinite-queries.md
@@ -141,3 +141,48 @@ queryClient.setQueryData('projects', data => ({
   pageParams: data.pageParams.slice(1),
 }))
 ```
+
+## What if I want to enable/disable infinite queries reactively?
+
+Sometimes you may want to enable or disable a Query by using a svelte [reactive statement](https://svelte.dev/tutorial/reactive-statements). In this case, you can use the `setEnabled` function:
+
+```markdown
+<script>
+  import { useInfiniteQuery } from '@sveltestack/svelte-query'
+
+  export let isEnabled = false;
+
+  const queryResult = useInfiniteQuery('projects', fetchProjects, {
+    getNextPageParam: lastGroup => lastGroup.nextId || undefined,
+  })
+
+  $: queryResult.setEnabled(isEnabled)
+</script>
+
+{#if $queryResult.status === 'idle'}
+  <button on:click={() => isEnabled = true}>Enable</button>
+{#if $queryResult.status === 'loading'}
+  Loading...
+{:else if $queryResult.status === 'error'}
+  <span>Error: {$queryResult.error.message}</span>
+{:else}
+  <div>
+    {#each $queryResult.data.pages as page}
+      {#each page.data as project}
+        <p>{project.name}</p>
+      {/each}
+    {/each}
+  </div>
+  <div>
+    <button
+      on:click={() => $queryResult.fetchNextPage()}
+      disabled={!$queryResult.hasNextPage || $queryResult.isFetchingNextPage}>
+      {#if $queryResult.isFetching}
+        Loading more...
+      {:else if $queryResult.hasNextPage}
+        Load More
+      {:else}Nothing more to load{/if}
+    </button>
+  </div>
+{/if}
+```

--- a/docs/src/pages/guides/queries.md
+++ b/docs/src/pages/guides/queries.md
@@ -86,3 +86,32 @@ If booleans aren't your thing, you can always use the `status` state as well:
   </ul>
 {/if}
 ```
+
+## What if I want to enable/disable queries reactively?
+
+Sometimes you may want to enable or disable a Query by using a svelte [reactive statement](https://svelte.dev/tutorial/reactive-statements). In this case, you can use the `setEnabled` function:
+
+```markdown
+<script>
+  import { useQuery } from '@sveltestack/svelte-query';
+
+  export let isEnabled = false;
+
+  const queryResult = useQuery('todos', fetchTodos)
+  $: queryResult.setEnabled(isEnabled)
+</script>
+
+{#if $queryResult.isIdle}
+  <button on:click={() => isEnabled = true}>Enable</button>
+{:else if $queryResult.isLoading}
+  <span>Loading...</span>
+{:else if $queryResult.isError}
+  <span>Error: {$queryResult.error.message}</span>
+{:else}
+  <ul>
+    {#each $queryResult.data as todo}
+      <li>{todo.title}</li>
+    {/each}
+  </ul>
+{/if}
+```

--- a/src/infiniteQuery/useInfiniteQuery.ts
+++ b/src/infiniteQuery/useInfiniteQuery.ts
@@ -79,5 +79,9 @@ export default function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnD
         }
     }
 
-    return { subscribe, setOptions }
+    function setEnabled(enabled: boolean): void {
+        observer.setOptions({ ...observer.options, enabled })
+    }
+
+    return { subscribe, setOptions, setEnabled }
 }

--- a/src/infiniteQuery/useInfiniteQuery.ts
+++ b/src/infiniteQuery/useInfiniteQuery.ts
@@ -79,9 +79,13 @@ export default function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnD
         }
     }
 
-    function setEnabled(enabled: boolean): void {
-        observer.setOptions({ ...observer.options, enabled })
+    function updateOptions(options: Partial<UseInfiniteQueryOptions<TQueryFnData, TError, TData>>): void {
+        observer.setOptions({ ...observer.options, ...options })
     }
 
-    return { subscribe, setOptions, setEnabled }
+    function setEnabled(enabled: boolean): void {
+        updateOptions({ enabled })
+    }
+
+    return { subscribe, setOptions, updateOptions, setEnabled }
 }

--- a/src/query/useQuery.ts
+++ b/src/query/useQuery.ts
@@ -75,5 +75,9 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
         }
     }
 
-    return { subscribe, setOptions }
+    function setEnabled(enabled: boolean): void {
+        observer.setOptions({ ...observer.options, enabled })
+    }
+
+    return { subscribe, setOptions, setEnabled }
 }

--- a/src/query/useQuery.ts
+++ b/src/query/useQuery.ts
@@ -75,9 +75,13 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
         }
     }
 
-    function setEnabled(enabled: boolean): void {
-        observer.setOptions({ ...observer.options, enabled })
+    function updateOptions(options: Partial<UseQueryOptions<TQueryFnData, TError, TData>>): void {
+        observer.setOptions({ ...observer.options, ...options })
     }
 
-    return { subscribe, setOptions, setEnabled }
+    function setEnabled(enabled: boolean): void {
+        updateOptions({ enabled })
+    }
+
+    return { subscribe, setOptions, updateOptions, setEnabled }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export interface UseQueryStoreResult<
     (queryKey: QueryKey, options?: UseQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, queryFn: QueryFunction<TQueryFnData>, options?: UseQueryOptions<TQueryFnData, TError, TData>): any;
   }
+  setEnabled(enabled: boolean): void
 }
 
 // use options.infinite = true for infinite Query
@@ -43,6 +44,7 @@ TData = TQueryFnData,
     (queryKey: QueryKey, options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, queryFn: QueryFunction<TQueryFnData>, options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): any;
   }
+  setEnabled(enabled: boolean): void
 }
 
 export interface UseInfiniteQueryOptions<

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,12 +15,13 @@ export interface UseQueryStoreResult<
   TError = unknown,
   TData = TQueryFnData
   > extends Readable<UseQueryResult<TData, TError>> {
+  setEnabled(enabled: boolean): void
   setOptions: {
     (options: UseQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, options?: UseQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, queryFn: QueryFunction<TQueryFnData>, options?: UseQueryOptions<TQueryFnData, TError, TData>): any;
   }
-  setEnabled(enabled: boolean): void
+  updateOptions(options: Partial<UseQueryOptions<TQueryFnData, TError, TData>>): void
 }
 
 // use options.infinite = true for infinite Query
@@ -39,12 +40,13 @@ TQueryFnData = unknown,
 TError = unknown,
 TData = TQueryFnData,
   > extends Readable<UseInfiniteQueryResult<TData, TError>> {
+  setEnabled(enabled: boolean): void
   setOptions: {
     (options: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): any;
     (queryKey: QueryKey, queryFn: QueryFunction<TQueryFnData>, options?: UseInfiniteQueryOptions<TQueryFnData, TError, TData>): any;
   }
-  setEnabled(enabled: boolean): void
+  updateOptions(options: Partial<UseInfiniteQueryOptions<TQueryFnData, TError, TData>>): void
 }
 
 export interface UseInfiniteQueryOptions<


### PR DESCRIPTION
In some situations, we need to enable or disable queries using svelte reactive statements.

We can do this using the `setOptions` method but it forces us to pass all options.
It could be very useful to have a `setEnabled` shortcut function which reuse existing options and only update the `enabled` option.

It allows this code:

```svelte
<script>
  import { useQuery } from '@sveltestack/svelte-query'

  let isQueryEnabled = false;

  const queryResult = useQuery('projects', getProjects, { enabled: isQueryEnabled })
  $: queryResult.setOptions('projects', getProjects, { enabled: isQueryEnabled })
</script>
```

to become

```svelte
<script>
  import { useQuery } from '@sveltestack/svelte-query'

  let isQueryEnabled = false;

  const queryResult = useQuery('projects', getProjects)
  $: queryResult.setEnabled(isQueryEnabled)
</script>
```

It makes the code more readable and understandable.

Do you agree?