### PR TITLE
fix: update queryHash when queryKey is updated using updateOptions

### DIFF
--- a/src/infiniteQuery/useInfiniteQuery.ts
+++ b/src/infiniteQuery/useInfiniteQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-shadow */
 import { readable } from 'svelte/store'
 
-import { parseQueryArgs } from '../queryCore/core/utils'
+import { hashQueryKeyByOptions, parseQueryArgs } from '../queryCore/core/utils'
 import { useQueryClient } from '../queryClientProvider'
 import { InfiniteQueryObserver } from '../queryCore/core/infiniteQueryObserver'
 import { notifyManager, QueryClient, QueryFunction, QueryKey } from '../queryCore/core'
@@ -83,7 +83,13 @@ export default function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnD
     }
 
     function updateOptions(options: Partial<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>>): void {
-        observer.setOptions({ ...observer.options, ...options })
+        const mergedOptions = { ...observer.options, ...options }
+
+        if (options.queryKey && !options.queryHash && options.queryKey !== observer.options.queryKey) {
+            mergedOptions.queryHash = hashQueryKeyByOptions(options.queryKey, mergedOptions)
+        }
+
+        observer.setOptions(mergedOptions)
     }
 
     function setEnabled(enabled: boolean): void {

--- a/src/infiniteQuery/useInfiniteQuery.ts
+++ b/src/infiniteQuery/useInfiniteQuery.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-shadow */
 import { readable } from 'svelte/store'
 
-import { hashQueryKeyByOptions, parseQueryArgs } from '../queryCore/core/utils'
+import { parseQueryArgs } from '../queryCore/core/utils'
 import { useQueryClient } from '../queryClientProvider'
 import { InfiniteQueryObserver } from '../queryCore/core/infiniteQueryObserver'
 import { notifyManager, QueryClient, QueryFunction, QueryKey } from '../queryCore/core'
@@ -83,13 +83,7 @@ export default function useInfiniteQuery<TQueryFnData, TError, TData = TQueryFnD
     }
 
     function updateOptions(options: Partial<UseInfiniteQueryOptions<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>>): void {
-        const mergedOptions = { ...observer.options, ...options }
-
-        if (options.queryKey && !options.queryHash && options.queryKey !== observer.options.queryKey) {
-            mergedOptions.queryHash = hashQueryKeyByOptions(options.queryKey, mergedOptions)
-        }
-
-        observer.setOptions(mergedOptions)
+        observer.updateOptions(options)
     }
 
     function setEnabled(enabled: boolean): void {

--- a/src/query/useQuery.ts
+++ b/src/query/useQuery.ts
@@ -2,7 +2,7 @@
 import { readable } from 'svelte/store'
 
 import { notifyManager, QueryObserver } from '../queryCore/core'
-import { hashQueryKeyByOptions, parseQueryArgs } from '../queryCore/core/utils'
+import { parseQueryArgs } from '../queryCore/core/utils'
 import { useQueryClient } from '../queryClientProvider'
 import type { QueryClient, QueryFunction, QueryKey } from '../queryCore/core'
 import type { UseQueryOptions, UseQueryStoreResult } from '../types'
@@ -79,13 +79,7 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
     }
 
     function updateOptions(options: Partial<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>>): void {
-        const mergedOptions = { ...observer.options, ...options }
-
-        if (options.queryKey && !options.queryHash && options.queryKey !== observer.options.queryKey) {
-            mergedOptions.queryHash = hashQueryKeyByOptions(options.queryKey, mergedOptions)
-        }
-
-        observer.setOptions(mergedOptions)
+        observer.updateOptions(options)
     }
 
     function setEnabled(enabled: boolean): void {

--- a/src/query/useQuery.ts
+++ b/src/query/useQuery.ts
@@ -2,7 +2,7 @@
 import { readable } from 'svelte/store'
 
 import { notifyManager, QueryObserver } from '../queryCore/core'
-import { parseQueryArgs } from '../queryCore/core/utils'
+import { hashQueryKeyByOptions, parseQueryArgs } from '../queryCore/core/utils'
 import { useQueryClient } from '../queryClientProvider'
 import type { QueryClient, QueryFunction, QueryKey } from '../queryCore/core'
 import type { UseQueryOptions, UseQueryStoreResult } from '../types'
@@ -79,7 +79,13 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
     }
 
     function updateOptions(options: Partial<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>>): void {
-        observer.setOptions({ ...observer.options, ...options })
+        const mergedOptions = { ...observer.options, ...options }
+
+        if (options.queryKey && !options.queryHash && options.queryKey !== observer.options.queryKey) {
+            mergedOptions.queryHash = hashQueryKeyByOptions(options.queryKey, mergedOptions)
+        }
+
+        observer.setOptions(mergedOptions)
     }
 
     function setEnabled(enabled: boolean): void {

--- a/src/queryCore/core/queryObserver.ts
+++ b/src/queryCore/core/queryObserver.ts
@@ -1,4 +1,5 @@
 import {
+  hashQueryKeyByOptions,
   isServer,
   isValidTimeout,
   noop,
@@ -194,6 +195,25 @@ export class QueryObserver<
     ) {
       this.updateRefetchInterval()
     }
+  }
+
+  updateOptions(
+    options?: Partial<QueryObserverOptions<
+      TQueryFnData,
+      TError,
+      TData,
+      TQueryData,
+      TQueryKey
+    >>,
+    notifyOptions?: NotifyOptions
+  ): void {
+    const mergedOptions = { ...this.options, ...options }
+
+    if (options.queryKey && !options.queryHash && options.queryKey !== this.options.queryKey) {
+        mergedOptions.queryHash = hashQueryKeyByOptions(options.queryKey, mergedOptions)
+    }
+
+    this.setOptions(mergedOptions, notifyOptions)
   }
 
   getOptimisticResult(


### PR DESCRIPTION
Hi,

### Description

I noticed that when `queryKey` is updated using the new `updateOptions` method, the query is not refetched.
This happens because the previous `queryHash` is not updated.

In this PR, I detect if `queryKey` is updated and I manually update the `queryHash`.

### Reproduction

```svelte
<script>
  import { useQuery } from "@sveltestack/svelte-query";

  const query = useQuery(["entities", { search: ""  }], fetchEntities);

  function onSearch(e) {
    query.updateOptions({ queryKey: ["entities", { search: e.target.value }] });
  }
</script>

<input type="text" on:change={onSearch} />

{#if $query.isLoading}
  Loading...
{:else if $query.data}
  {#each $query.data as entity (entity.id)}
    <p>{entity.name}</p>
  {/each}
{/if}
```