### PR TITLE
feat(usequery): provide AbortSignal to queryFn

### DIFF
--- a/docs/src/pages/guides/query-cancellation.md
+++ b/docs/src/pages/guides/query-cancellation.md
@@ -3,38 +3,120 @@ id: query-cancellation
 title: Query Cancellation
 ---
 
-By default, queries that unmount or become unused before their promises are resolved are simply ignored instead of canceled. Why is this?
+[_Previous method requiring a `cancel` function_](#old-cancel-function)
 
-- For most applications, ignoring out-of-date queries is sufficient.
-- Cancellation APIs may not be available for every query function.
-- If cancellation APIs are available, they typically vary in implementation between utilities/libraries (eg. Fetch vs Axios vs XMLHttpRequest).
+Svelte Query provides each query function with an [`AbortSignal` instance](https://developer.mozilla.org/docs/Web/API/AbortSignal) **if it's available in your runtime environment**. When a query becomes out-of-date or inactive, this `signal` will become aborted. This means that all queries are cancellable and you can respond to the cancellation inside your query function if desired. The best part about this is that it allow you to continue to use normal async/await syntax while getting all the benefits of automatic cancellation. Additionally, this solution works better with TypeScript than the old solution.
 
-But don't worry! If your queries are high-bandwidth or potentially very expensive to download, Svelte Query exposes a generic way to **cancel** query requests using a cancellation token or other related API. To integrate with this feature, attach a `cancel` function to the promise returned by your query that implements your request cancellation. When a query becomes out-of-date or inactive, this `promise.cancel` function will be called (if available):
+The `AbortController` API is available in [most runtime environments](https://developer.mozilla.org/docs/Web/API/AbortController#browser_compatibility), but if the runtime environment does not support it then the query function will receive `undefined` in its place. You may choose to polyfill the `AbortController` API if you wish, there are [several available](https://www.npmjs.com/search?q=abortcontroller%20polyfill).
+
+## Using `fetch`
+
+```js
+const query = useQuery('todos', async ({ signal }) => {
+  const todosResponse = await fetch('/todos', {
+    // Pass the signal to one fetch
+    signal,
+  })
+  const todos = await todosResponse.json()
+  const todoDetails = todos.map(async ({ details } => {
+    const response = await fetch(details, {
+      // Or pass it to several
+      signal,
+    })
+    return response.json()
+  })
+  return Promise.all(todoDetails)
+})
+```
 
 ## Using `axios`
 
+### Using `axios` [v0.22.0+](https://github.com/axios/axios/releases/tag/v0.22.0)
 ```js
-import { CancelToken } from 'axios'
-
-const query = useQuery('todos', () => {
+import axios from 'axios'
+const query = useQuery('todos', ({ signal }) =>
+  axios.get('/todos', {
+    // Pass the signal to `axios`
+    signal,
+  })
+)
+```
+### Using an `axios` version less than v0.22.0
+```js
+import axios from 'axios'
+const query = useQuery('todos', ({ signal }) => {
   // Create a new CancelToken source for this request
+  const CancelToken = axios.CancelToken
   const source = CancelToken.source()
-
   const promise = axios.get('/todos', {
     // Pass the source token to your request
     cancelToken: source.token,
   })
-
-  // Cancel the request if Svelte Query calls the `promise.cancel` method
-  promise.cancel = () => {
+  // Cancel the request if Svelte Query signals to abort
+  signal?.addEventListener('abort', () => {
     source.cancel('Query was cancelled by Svelte Query')
-  }
-
+  })
   return promise
 })
 ```
 
-## Using `fetch`
+## Using `XMLHttpRequest`
+```js
+const query = useQuery('todos', ({ signal }) => {
+  return new Promise((resolve, reject) => {
+    var oReq = new XMLHttpRequest()
+    oReq.addEventListener('load', () => {
+      resolve(JSON.parse(oReq.responseText))
+    })
+    signal?.addEventListener('abort', () => {
+      oReq.abort()
+      reject()
+    })
+    oReq.open('GET', '/todos')
+    oReq.send()
+  })
+})
+```
+## Manual Cancellation
+You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries(key)`. If `promise.cancel` is available or you have consumed the `singal` passed to the query function then Svelte Query will cancel the request.
+```js
+const [queryKey] = useState('todos')
+const query = useQuery(queryKey, await ({ signal }) => {
+  const resp = fetch('/todos', { signal })
+  return resp.json()
+})
+const queryClient = useQueryClient()
+return (
+  <button onClick={(e) => {
+    e.preventDefault()
+    queryClient.cancelQueries(queryKey)
+   }}>Cancel</button>
+)
+```
+## Old `cancel` function
+Don't worry! The previous cancellation functionality will continue to work. But we do recommend that you move away from [the withdrawn cancelable promise proposal](https://github.com/tc39/proposal-cancelable-promises) to the [new `AbortSignal` interface](#_top) which has been [stardardized](https://dom.spec.whatwg.org/#interface-abortcontroller) as a general purpose construct for aborting ongoing activities in [most browsers](https://caniuse.com/abortcontroller) and in [Node](https://nodejs.org/api/globals.html#globals_class_abortsignal). The old cancel function might be removed in a future major version.
+To integrate with this feature, attach a `cancel` function to the promise returned by your query that implements your request cancellation. When a query becomes out-of-date or inactive, this `promise.cancel` function will be called (if available).
+## Using `axios` with `cancel` function
+
+```js
+import axios from 'axios'
+const query = useQuery('todos', () => {
+  // Create a new CancelToken source for this request
+  const CancelToken = axios.CancelToken
+  const source = CancelToken.source()
+  const promise = axios.get('/todos', {
+    // Pass the source token to your request
+    cancelToken: source.token,
+  })
+  // Cancel the request if Svelte Query calls the `promise.cancel` method
+  promise.cancel = () => {
+    source.cancel('Query was cancelled by Svelte Query')
+  }
+  return promise
+})
+```
+
+## Using `fetch` with `cancel` function
 
 ```js
 const query = useQuery('todos', () => {
@@ -42,46 +124,12 @@ const query = useQuery('todos', () => {
   const controller = new AbortController()
   // Get the abortController's signal
   const signal = controller.signal
-
   const promise = fetch('/todos', {
     method: 'get',
     // Pass the signal to your request
     signal,
   })
-
   // Cancel the request if Svelte Query calls the `promise.cancel` method
   promise.cancel = () => controller.abort()
-
   return promise
 })
-```
-
-## Manual Cancellation
-
-You might want to cancel a query manually. For example, if the request takes a long time to finish, you can allow the user to click a cancel button to stop the request. To do this, you just need to call `queryClient.cancelQueries(key)`. If `promise.cancel` is available, Svelte Query will cancel the request.
-
-```markdown
-<script>
-  const query = useQuery(queryKey, () => {
-    const controller = new AbortController()
-    const signal = controller.signal
-    const promise = fetch('/todos', {
-      method: 'get',
-      signal,
-    })
-    // Cancel the request if Svelte Query calls the `promise.cancel` method
-    promise.cancel = () => controller.abort()
-    return promise
-  })
-
-  const queryClient = useQueryClient();
-</script>
-
-<button on:click={(e) => {
-  e.preventDefault();
-  queryClient.cancelQueries(queryKey);
-  }}>
-  Cancel
-</button>
-
-```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sveltestack/svelte-query",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@sveltestack/svelte-query",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.9.0",

--- a/src/queryCore/core/infiniteQueryBehavior.ts
+++ b/src/queryCore/core/infiniteQueryBehavior.ts
@@ -1,6 +1,7 @@
 import type { QueryBehavior } from './query'
 import { isCancelable } from './retryer'
 import type { InfiniteData, QueryFunctionContext, QueryOptions } from './types'
+import { getAbortController } from './utils'
 
 export function infiniteQueryBehavior<
   TQueryFnData,
@@ -16,6 +17,8 @@ export function infiniteQueryBehavior<
         const isFetchingPreviousPage = fetchMore?.direction === 'backward'
         const oldPages = context.state.data?.pages || []
         const oldPageParams = context.state.data?.pageParams || []
+        const abortController = getAbortController()
+        const abortSignal = abortController?.signal
         let newPageParams = oldPageParams
         let cancelled = false
 
@@ -40,6 +43,7 @@ export function infiniteQueryBehavior<
 
           const queryFnContext: QueryFunctionContext = {
             queryKey: context.queryKey,
+            signal: abortSignal,
             pageParam: param,
           }
 
@@ -114,6 +118,7 @@ export function infiniteQueryBehavior<
 
         finalPromiseAsAny.cancel = () => {
           cancelled = true
+          abortController?.abort()
           if (isCancelable(promise)) {
             promise.cancel()
           }

--- a/src/queryCore/core/types.ts
+++ b/src/queryCore/core/types.ts
@@ -15,6 +15,7 @@ export interface QueryFunctionContext<
   TPageParam = any
 > {
   queryKey: TQueryKey
+  signal?: AbortSignal
   pageParam?: TPageParam
 }
 

--- a/src/queryCore/core/utils.ts
+++ b/src/queryCore/core/utils.ts
@@ -412,3 +412,9 @@ export function scheduleMicrotask(callback: () => void): void {
       })
     )
 }
+
+export function getAbortController(): AbortController | undefined {
+  if (typeof AbortController === 'function') {
+    return new AbortController()
+  }
+}

--- a/storybook/package-lock.json
+++ b/storybook/package-lock.json
@@ -19082,7 +19082,8 @@
             "version": "1.6.22",
             "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
             "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "@mdx-js/util": {
             "version": "1.6.22",
@@ -20673,7 +20674,8 @@
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
             "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
@@ -20738,13 +20740,15 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
             "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "ansi-align": {
             "version": "3.0.0",
@@ -26160,7 +26164,8 @@
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.2.tgz",
             "integrity": "sha512-O8DMCl32V34RrD+ZHxcAPc2+kYytuDIoQYjY36RVdsLK7uHjgNVvFec4yv0X6LgB4YEZgSvK5QtFi5YVqEpoMA==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "md5.js": {
             "version": "1.3.5",
@@ -27751,7 +27756,8 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.1.1.tgz",
             "integrity": "sha512-CNnpzPOMDUors/WcN23IUkBvdHuzJfr5UuZxW02TyVW5hCmFME3cbxucF26EujKyTt4ageBrLDyQ6JAtjGIzgQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "react-dev-utils": {
             "version": "11.0.4",
@@ -29613,7 +29619,8 @@
             "version": "0.12.9",
             "resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.12.9.tgz",
             "integrity": "sha512-SGE7Odznj4dqZtUVIWcoPCvZ9gHImxVIIjrz+O3DDSi0j4OaSLim6MRF4UdhlBKeW3glSRc+tXNSKYvM5x+Dyw==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "svelte-loader": {
             "version": "3.1.0",
@@ -30426,7 +30433,8 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
             "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "use-latest": {
             "version": "1.2.0",
@@ -31186,7 +31194,8 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
             "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-            "dev": true
+            "dev": true,
+            "requires": {}
         },
         "webpack-hot-middleware": {
             "version": "2.25.0",


### PR DESCRIPTION
I tried to retrofit the new query cancellation feature to svelte-query.

You can find the merge request on react-query [here](https://github.com/tannerlinsley/react-query/pull/2782)