### PR TITLE
Hydration modules exported twice

### DIFF
--- a/src/queryCore/index.ts
+++ b/src/queryCore/index.ts
@@ -1,5 +1,4 @@
 export * from './core'
-export * from './hydration'
 export * from './persistQueryClient-experimental'
 export * from './createWebStoragePersistor-experimental'
 export * from './createAsyncStoragePersistor-experimental'


### PR DESCRIPTION
the following error is occurring when using `hydrate` or `dehydrate`

```
"hydrate" cannot be exported from ../../node_modules/@sveltestack/svelte-query/svelte/queryCore/core/hydration.js as it is a reexport that references itself.
```

I discovered it's because the hydration module is exported twice, so just removed one of them.

It's exported as part of './core' in the same file.
