### PR TITLE
fix: make svelte external

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
+    "svelte": "^3.29.0",
     "broadcast-channel": "^4.5.0"
   },
   "peerDependenciesMeta": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -18,6 +18,7 @@ export default {
 		{ file: pkg.main, 'format': 'umd', name },
 		{ file: pkg.main.replace('.js', '.min.js'), format: 'iife', name, plugins: [terser()] }
 	],
+	external: (id) => id.startsWith('svelte'),
 	plugins: [
 		svelte({
 			preprocess: autoPreprocess()


### PR DESCRIPTION
I'm currently working on a project where I encounter the error `Function called outside component initialization` which mean I have multiple version of svelte loaded somehow. When I explorer your library I noticed you load svelte components without exposing it as a peerDependency. In some scenario you can end up with multiple version of svelte. 