### PR TITLE
fix(queries): Fix stale values after calling set/updateOptions

### DIFF
--- a/src/query/useQuery.ts
+++ b/src/query/useQuery.ts
@@ -43,8 +43,10 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
     // Include callbacks in batch renders
     defaultedOptions = setBatchCalls<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>>(defaultedOptions)
     const observer = new QueryObserver<TQueryFnData, TError, TData, TQueryFnData, TQueryKey>(client, defaultedOptions)
+    let setter: any // Subscriber<UseQueryStoreResult<TQueryFnData, TError, TData, TQueryKey>> ???
 
     const { subscribe } = readable(observer.getCurrentResult(), set => {
+        setter = set
         return observer.subscribe(notifyManager.batchCalls(set))
     })
 
@@ -76,10 +78,12 @@ export default function useQuery<TQueryFnData = unknown, TError = unknown, TData
         if (observer.hasListeners()) {
             observer.setOptions(defaultedOptions, { listeners: false })
         }
+        if (setter) setter(observer.getCurrentResult())
     }
 
     function updateOptions(options: Partial<UseQueryOptions<TQueryFnData, TError, TData, TQueryKey>>): void {
         observer.updateOptions(options)
+        if (setter) setter(observer.getCurrentResult())
     }
 
     function setEnabled(enabled: boolean): void {


### PR DESCRIPTION
This ensures that the cached value or undefined are set when changing the query key, so incorrect data is not shown when updating and setting options.

This is attempting to address #89, and seems to fix that issue for me, but I'm not sure what other implications this has.