### PR TITLE
docs(queries): fix sample code on queries guide

### DIFF
--- a/docs/src/pages/guides/queries.md
+++ b/docs/src/pages/guides/queries.md
@@ -97,7 +97,8 @@ Sometimes you may want to enable or disable a Query by using a svelte [reactive 
 
   export let isEnabled = false;
 
-  const queryResult = useQuery('todos', fetchTodos)
+  const queryResult = useQuery('todos', fetchTodos, { enabled: isEnabled })
+  
   $: queryResult.setEnabled(isEnabled)
 </script>
 


### PR DESCRIPTION
I found that we need to pass the `enabled` property to `useQuery` too. 